### PR TITLE
Fix uninlined_format_args clippy rule

### DIFF
--- a/frost-client/src/cli/coordinator.rs
+++ b/frost-client/src/cli/coordinator.rs
@@ -68,7 +68,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
         group.server_url.clone().ok_or_eyre("server-url required")?
     };
     let server_url_parsed =
-        Url::parse(&format!("https://{}", server_url)).wrap_err("error parsing server-url")?;
+        Url::parse(&format!("https://{server_url}")).wrap_err("error parsing server-url")?;
 
     let signers = signers
         .iter()

--- a/frost-client/src/cli/dkg.rs
+++ b/frost-client/src/cli/dkg.rs
@@ -54,7 +54,7 @@ pub(crate) async fn dkg_for_ciphersuite<C: Ciphersuite + MaybeIntoEvenY + 'stati
     let config = Config::read(config_path.clone())?;
 
     let server_url_parsed =
-        Url::parse(&format!("https://{}", server_url)).wrap_err("error parsing server-url")?;
+        Url::parse(&format!("https://{server_url}")).wrap_err("error parsing server-url")?;
 
     let comm_pubkey = config
         .communication_key

--- a/frost-client/src/cli/participant.rs
+++ b/frost-client/src/cli/participant.rs
@@ -63,7 +63,7 @@ pub(crate) async fn run_for_ciphersuite<C: RandomizedCiphersuite + 'static>(
         group.server_url.clone().ok_or_eyre("server-url required")?
     };
     let server_url_parsed =
-        Url::parse(&format!("https://{}", server_url)).wrap_err("error parsing server-url")?;
+        Url::parse(&format!("https://{server_url}")).wrap_err("error parsing server-url")?;
 
     let group_participants = group.participant.clone();
     let pargs = args::ProcessedArgs {

--- a/frost-client/src/cli/session.rs
+++ b/frost-client/src/cli/session.rs
@@ -45,7 +45,7 @@ pub async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
         .pubkey
         .clone();
 
-    let mut client = Client::new(format!("https://{}", server_url));
+    let mut client = Client::new(format!("https://{server_url}"));
 
     let mut rng = thread_rng();
 
@@ -77,7 +77,7 @@ pub async fn list(args: &Command) -> Result<(), Box<dyn Error>> {
                 .iter()
                 .map(|pubkey| config.contact_by_pubkey(pubkey))
                 .collect();
-            eprintln!("Session with ID {}", session_id);
+            eprintln!("Session with ID {session_id}");
             eprintln!(
                 "Coordinator: {}",
                 coordinator

--- a/frost-client/src/coordinator/comms/cli.rs
+++ b/frost-client/src/coordinator/comms/cli.rs
@@ -52,7 +52,7 @@ where
         let mut commitments_list: BTreeMap<Identifier<C>, SigningCommitments<C>> = BTreeMap::new();
 
         for i in 1..=num_of_participants {
-            writeln!(output, "Identifier for participant {:?} (hex encoded): ", i)?;
+            writeln!(output, "Identifier for participant {i:?} (hex encoded): ")?;
             let id_value = read_identifier(input)?;
             validate(id_value, pub_key_package, &participants_list)?;
             participants_list.push(id_value);

--- a/frost-client/src/coordinator/input.rs
+++ b/frost-client/src/coordinator/input.rs
@@ -22,14 +22,10 @@ pub fn read_from_file_or_stdin(
         } else {
             let p = Path::new(&file_path);
             if p.exists() {
-                writeln!(output, "Reading {} from {}", object_name, file_path)?;
+                writeln!(output, "Reading {object_name} from {file_path}")?;
                 Some(p)
             } else {
-                writeln!(
-                    output,
-                    "File not found: {}\nWill read from stdin",
-                    file_path
-                )?;
+                writeln!(output, "File not found: {file_path}\nWill read from stdin")?;
                 None
             }
         }
@@ -37,7 +33,7 @@ pub fn read_from_file_or_stdin(
     match file_path {
         Some(file_path) => Ok(fs::read_to_string(file_path)?),
         None => {
-            writeln!(output, "Paste the {}: ", object_name)?;
+            writeln!(output, "Paste the {object_name}: ")?;
             let mut key_package = String::new();
             input.read_line(&mut key_package)?;
             Ok(key_package)

--- a/frost-client/src/coordinator/main.rs
+++ b/frost-client/src/coordinator/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match r {
         Ok(_) => std::process::exit(0),
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(1);
         }
     }

--- a/frost-client/src/coordinator/tests/common/mod.rs
+++ b/frost-client/src/coordinator/tests/common/mod.rs
@@ -73,16 +73,16 @@ pub fn get_helpers() -> Helpers {
 
     let commitments_from_part_3 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"identifier\":\"{}\",\"signing_share\":\"{}\",\"commitment\":[\"{}\",\"{}\"]}}", participant_id_3, signing_share, commitments[0], commitments[1]);
 
-    let signing_package_helper = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"signing_commitments\":{{\"{}\":{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{}\",\"binding\":\"{}\"}},\"{}\":{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{}\",\"binding\":\"{}\"}}}},\"message\":\"{}\"}}", participant_id_1, hiding_commitment_1, binding_commitment_1, participant_id_3, hiding_commitment_3, binding_commitment_3, message);
+    let signing_package_helper = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"signing_commitments\":{{\"{participant_id_1}\":{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{hiding_commitment_1}\",\"binding\":\"{binding_commitment_1}\"}},\"{participant_id_3}\":{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{hiding_commitment_3}\",\"binding\":\"{binding_commitment_3}\"}}}},\"message\":\"{message}\"}}");
 
-    let signature_1 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"share\":\"{}\"}}", signature_share_1);
-    let signature_3 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"share\":\"{}\"}}", signature_share_3);
+    let signature_1 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"share\":\"{signature_share_1}\"}}");
+    let signature_3 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"share\":\"{signature_share_3}\"}}");
 
-    let pub_key_package = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"verifying_shares\":{{\"{}\":\"{}\",\"{}\":\"{}\",\"{}\":\"{}\"}},\"verifying_key\":\"{}\"}}", participant_id_1, public_key_1, participant_id_2, public_key_2, participant_id_3, public_key_3, verifying_key).to_string();
+    let pub_key_package = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"verifying_shares\":{{\"{participant_id_1}\":\"{public_key_1}\",\"{participant_id_2}\":\"{public_key_2}\",\"{participant_id_3}\":\"{public_key_3}\"}},\"verifying_key\":\"{verifying_key}\"}}").to_string();
 
-    let commitments_input_1 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{}\", \"binding\":\"{}\"}}", hiding_commitment_1, binding_commitment_1);
+    let commitments_input_1 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{hiding_commitment_1}\", \"binding\":\"{binding_commitment_1}\"}}");
 
-    let commitments_input_3 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{}\", \"binding\":\"{}\"}}", hiding_commitment_3, binding_commitment_3);
+    let commitments_input_3 = format!("{{\"header\":{{\"version\":0,\"ciphersuite\":\"FROST-ED25519-SHA512-v1\"}},\"hiding\":\"{hiding_commitment_3}\", \"binding\":\"{binding_commitment_3}\"}}");
 
     Helpers {
         participant_id_1,

--- a/frost-client/src/coordinator/tests/steps.rs
+++ b/frost-client/src/coordinator/tests/steps.rs
@@ -105,13 +105,12 @@ async fn check_step_1() {
 
     let signing_commitments = build_signing_commitments();
 
-    let input = format!("{}\n{}\n", num_of_participants, pub_key_package);
+    let input = format!("{num_of_participants}\n{pub_key_package}\n");
 
     let pargs = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
 
     let input = format!(
-        "{}\n{}\n{}\n{}\n",
-        participant_id_1, commitments_input_1, participant_id_3, commitments_input_3
+        "{participant_id_1}\n{commitments_input_1}\n{participant_id_3}\n{commitments_input_3}\n"
     );
     let mut buf = BufWriter::new(Vec::new());
 
@@ -150,8 +149,7 @@ async fn check_step_2() {
     let mut buf = BufWriter::new(Vec::new());
 
     let input = format!(
-        "2\n{}\n{}\n{}\n{}\n",
-        pub_key_package, message, commitments_from_part_1, commitments_from_part_3
+        "2\n{pub_key_package}\n{message}\n{commitments_from_part_1}\n{commitments_from_part_3}\n"
     );
     let pargs = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
 
@@ -166,7 +164,7 @@ async fn check_step_2() {
 
     assert!(signing_package == expected_signing_package);
 
-    let expected = format!("Signing Package:\n{}\n", signing_package_helper);
+    let expected = format!("Signing Package:\n{signing_package_helper}\n");
 
     let (_, res) = &buf.into_parts();
     let actual = String::from_utf8(res.as_ref().unwrap().to_owned()).unwrap();
@@ -194,7 +192,7 @@ async fn check_step_3() {
     let mut buf = BufWriter::new(Vec::new());
     let args = Args::default();
 
-    let input = format!("2\n{}\n{}\n", pub_key_package, message);
+    let input = format!("2\n{pub_key_package}\n{message}\n");
     let pargs = ProcessedArgs::new(&args, &mut input.as_bytes(), &mut buf).unwrap();
 
     // keygen output
@@ -203,7 +201,7 @@ async fn check_step_3() {
 
     // step 2 input
 
-    let input = format!("{}\n{}\n", signature_1, signature_3);
+    let input = format!("{signature_1}\n{signature_3}\n");
 
     let mut valid_input = input.as_bytes();
 
@@ -232,7 +230,7 @@ async fn check_step_3() {
     .await
     .unwrap();
 
-    let expected = format!("Please enter JSON encoded signature shares for participant {}:\nPlease enter JSON encoded signature shares for participant {}:\nSignature:\n{}\n", participant_id_1, participant_id_3, group_signature);
+    let expected = format!("Please enter JSON encoded signature shares for participant {participant_id_1}:\nPlease enter JSON encoded signature shares for participant {participant_id_3}:\nSignature:\n{group_signature}\n");
 
     let (_, res) = &buf.into_parts();
     let actual = String::from_utf8(res.as_ref().unwrap().to_owned()).unwrap();

--- a/frost-client/src/participant/comms/socket.rs
+++ b/frost-client/src/participant/comms/socket.rs
@@ -61,18 +61,18 @@ where
         // Read incoming network events.
         listener.for_each(|event| match event.network() {
             NetEvent::Connected(endpoint, false) => {
-                println!("Error connecting to server at {}", endpoint)
+                println!("Error connecting to server at {endpoint}")
             } // Used for explicit connections.
-            NetEvent::Connected(endpoint, true) => println!("Connected to server at {}", endpoint), // Used for explicit connections.
+            NetEvent::Connected(endpoint, true) => println!("Connected to server at {endpoint}"), // Used for explicit connections.
             NetEvent::Accepted(endpoint, _listener) => {
-                println!("Server accepted connection at {}", endpoint)
+                println!("Server accepted connection at {endpoint}")
             } // Tcp or Ws
             NetEvent::Message(endpoint, data) => {
                 println!("Received: {}", String::from_utf8_lossy(data));
                 input_tx.try_send((endpoint, data.to_vec())).unwrap();
             }
             NetEvent::Disconnected(endpoint) => {
-                println!("Disconnected from server at {}", endpoint)
+                println!("Disconnected from server at {endpoint}")
             } //Tcp or Ws
         });
     }

--- a/frost-client/src/participant/input.rs
+++ b/frost-client/src/participant/input.rs
@@ -22,14 +22,10 @@ pub fn read_from_file_or_stdin(
         } else {
             let p = Path::new(&file_path);
             if p.exists() {
-                writeln!(output, "Reading {} from {}", object_name, file_path)?;
+                writeln!(output, "Reading {object_name} from {file_path}")?;
                 Some(p)
             } else {
-                writeln!(
-                    output,
-                    "File not found: {}\nWill read from stdin",
-                    file_path
-                )?;
+                writeln!(output, "File not found: {file_path}\nWill read from stdin")?;
                 None
             }
         }
@@ -37,7 +33,7 @@ pub fn read_from_file_or_stdin(
     match file_path {
         Some(file_path) => Ok(fs::read_to_string(file_path)?),
         None => {
-            writeln!(output, "Paste the {}: ", object_name)?;
+            writeln!(output, "Paste the {object_name}: ")?;
             let mut key_package = String::new();
             input.read_line(&mut key_package)?;
             Ok(key_package)

--- a/frost-client/src/participant/main.rs
+++ b/frost-client/src/participant/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match r {
         Ok(_) => std::process::exit(0),
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(1);
         }
     }

--- a/frostd/tests/integration_tests.rs
+++ b/frostd/tests/integration_tests.rs
@@ -529,7 +529,7 @@ async fn test_http() -> Result<(), Box<dyn std::error::Error>> {
     }
     let r = r.json::<frostd::CreateNewSessionOutput>().await?;
     let session_id = r.session_id;
-    println!("Session ID: {}", session_id);
+    println!("Session ID: {session_id}");
 
     // Error tests
 

--- a/zcash-sign/src/main.rs
+++ b/zcash-sign/src/main.rs
@@ -39,7 +39,7 @@ fn generate(args: &Command) -> Result<(), Box<dyn Error>> {
     // TODO: make params selectable
     let unified_address_str = unified_address.encode(&MainNetwork);
 
-    println!("Orchard-only unified address: {:?}", unified_address_str);
+    println!("Orchard-only unified address: {unified_address_str:?}");
 
     let sapling_fvk = if *danger_dummy_sapling {
         let mut seed = [0u8; 64];
@@ -53,7 +53,7 @@ fn generate(args: &Command) -> Result<(), Box<dyn Error>> {
     let ufvk = UnifiedFullViewingKey::new(sapling_fvk, Some(fvk.clone())).unwrap();
     let ufvk_str = ufvk.encode(&MainNetwork);
 
-    println!("Unified Full Viewing Key: {:?}", ufvk_str);
+    println!("Unified Full Viewing Key: {ufvk_str:?}");
 
     Ok(())
 }
@@ -83,7 +83,7 @@ fn sign(args: &Command) -> Result<(), Box<dyn Error>> {
     tx.write(&mut tx_bytes).unwrap();
 
     fs::write(tx_path, BASE64_STANDARD.encode(&tx_bytes))?;
-    println!("Tx written to {}", tx_path);
+    println!("Tx written to {tx_path}");
 
     Ok(())
 }

--- a/zcash-sign/src/sign.rs
+++ b/zcash-sign/src/sign.rs
@@ -244,7 +244,7 @@ pub fn sign(
             );
             let mut buffer = String::new();
             let stdin = std::io::stdin();
-            println!("Input hex-encoded signature #{}: ", i);
+            println!("Input hex-encoded signature #{i}: ");
             stdin.read_line(&mut buffer).unwrap();
             let signature = hex::decode(buffer.trim()).unwrap();
             let signature: [u8; 64] = signature.try_into().unwrap();


### PR DESCRIPTION
We started getting clippy warnings for `uninlined_format_args`. This fixes those warnings.